### PR TITLE
Improve compatibility on Windows

### DIFF
--- a/tumblrcrawl.py
+++ b/tumblrcrawl.py
@@ -276,7 +276,7 @@ def usage():
 if __name__ == "__main__":
     # Catch keyboard interrupts
     signal.signal(signal.SIGINT, sigint_handler)
-    signal.signal(signal.SIGQUIT, sigint_handler)
+    signal.signal(getattr(signal, 'SIGQUIT', signal.SIGTERM), sigint_handler)
     
     # Basic name check
     if len(sys.argv) < 2:


### PR DESCRIPTION
`signal` doesn't have `SIGQUIT` on Windows. 

This change will make the script work on Windows without changing behavior on other OSs.